### PR TITLE
Fix swiftmailer configuration not being passed correctly

### DIFF
--- a/classes/OpenCFP/Application.php
+++ b/classes/OpenCFP/Application.php
@@ -52,12 +52,14 @@ final class Application extends SilexApplication
         $this->register(new ValidatorServiceProvider);
         $this->register(new TranslationServiceProvider);
         $this->register(new SwiftmailerServiceProvider, [
-            'host' => $this->config('mail.host'),
-            'port' => $this->config('mail.port'),
-            'username' => $this->config('mail.username'),
-            'password' => $this->config('mail.password'),
-            'encryption' => $this->config('mail.encryption'),
-            'auth_mode' => $this->config('mail.auth_mode')
+            'swiftmailer.options' => [
+                'host' => $this->config('mail.host'),
+                'port' => $this->config('mail.port'),
+                'username' => $this->config('mail.username'),
+                'password' => $this->config('mail.password'),
+                'encryption' => $this->config('mail.encryption'),
+                'auth_mode' => $this->config('mail.auth_mode'),
+            ],
         ]);
 
         $this->register(new SentryServiceProvider);


### PR DESCRIPTION
The swiftmailer configuration in config/*.yml was not being passed to the swiftmailer provider correctly. This commit puts the swiftmailer configuration inside a swiftmailer.options array, which fixes the problem.