### PR TITLE
Allow sorting on admin talks page

### DIFF
--- a/classes/OpenCFP/Domain/Entity/Mapper/Talk.php
+++ b/classes/OpenCFP/Domain/Entity/Mapper/Talk.php
@@ -14,10 +14,10 @@ class Talk extends Mapper
      * @param  integer $admin_user_id
      * @return array
      */
-    public function getAllPagerFormatted($admin_user_id)
+    public function getAllPagerFormatted($admin_user_id, $sort)
     {
         $talks = $this->all()
-            ->order(['created_at' => 'DESC'])
+            ->order($sort)
             ->with(['favorites']);
         $formatted = array();
 

--- a/classes/OpenCFP/Http/Controller/Admin/TalksController.php
+++ b/classes/OpenCFP/Http/Controller/Admin/TalksController.php
@@ -42,7 +42,11 @@ class TalksController extends BaseController
 
         // Create our default view for the navigation options
         $routeGenerator = function ($page) {
-            return '/admin/talks?page=' . $page;
+            $uri = '/admin/talks?page=' . $page;
+            if ($req->get('sort') !== null) {
+                $uri .= '&sort=' . $req->get('sort');
+            }
+            return $uri;
         };
         $view = new TwitterBootstrap3View();
         $pagination = $view->render(

--- a/classes/OpenCFP/Http/Controller/Admin/TalksController.php
+++ b/classes/OpenCFP/Http/Controller/Admin/TalksController.php
@@ -17,9 +17,18 @@ class TalksController extends BaseController
             return $this->redirectTo('login');
         }
 
+        $sort = [ "created_at" => "DESC" ];
+        if ($req->get('sort') !== null) {
+            switch ($req->get('sort')) {
+                case "title": $sort = [ "title" => "ASC" ]; break;
+                case "category": $sort = [ "category" => "ASC", "title" => "ASC" ]; break;
+                case "type": $sort = [ "type" => "ASC", "category" => "ASC", "title" => "ASC" ]; break;
+            }
+        }
+
         $admin_user_id = $this->app['sentry']->getUser()->getId();
         $mapper = $this->app['spot']->mapper('OpenCFP\Domain\Entity\Talk');
-        $pager_formatted_talks = $mapper->getAllPagerFormatted($admin_user_id);
+        $pager_formatted_talks = $mapper->getAllPagerFormatted($admin_user_id, $sort);
 
         // Set up our page stuff
         $adapter = new \Pagerfanta\Adapter\ArrayAdapter($pager_formatted_talks);

--- a/classes/OpenCFP/Http/Controller/Admin/TalksController.php
+++ b/classes/OpenCFP/Http/Controller/Admin/TalksController.php
@@ -41,7 +41,7 @@ class TalksController extends BaseController
         }
 
         // Create our default view for the navigation options
-        $routeGenerator = function ($page) {
+        $routeGenerator = function ($page) use ($req) {
             $uri = '/admin/talks?page=' . $page;
             if ($req->get('sort') !== null) {
                 $uri .= '&sort=' . $req->get('sort');

--- a/templates/admin/talks/_table.twig
+++ b/templates/admin/talks/_table.twig
@@ -1,10 +1,10 @@
 <table class="table table-striped">
     <thead>
         <tr>
-            <th align='left'><b><a href="talks?sort=title">Title</a></b></th>
-            <th align='left'><b><a href="talks?sort=type">Type</a></b></th>
-            <th align='left'><b><a href="talks?sort=category">Category</a></b></th>
-            <th align='left'><b><a href="talks">Created On</a></b></th>
+            <th align='left'><b><a href="/admin/talks?sort=title">Title</a></b></th>
+            <th align='left'><b><a href="/admin/talks?sort=type">Type</a></b></th>
+            <th align='left'><b><a href="/admin/talks?sort=category">Category</a></b></th>
+            <th align='left'><b><a href="/admin/talks">Created On</a></b></th>
             <th align='left'><b>Submitted by</b></th>
             <th>&nbsp;</th>
         </tr>

--- a/templates/admin/talks/_table.twig
+++ b/templates/admin/talks/_table.twig
@@ -1,10 +1,10 @@
 <table class="table table-striped">
     <thead>
         <tr>
-            <th align='left'><b>Title</b></th>
-            <th align='left'><b>Type</b></th>
-            <th align='left'><b>Category</b></th>
-            <th align='left'><b>Created On</b></th>
+            <th align='left'><b><a href="talks?sort=title">Title</a></b></th>
+            <th align='left'><b><a href="talks?sort=type">Type</a></b></th>
+            <th align='left'><b><a href="talks?sort=category">Category</a></b></th>
+            <th align='left'><b><a href="talks">Created On</a></b></th>
             <th align='left'><b>Submitted by</b></th>
             <th>&nbsp;</th>
         </tr>

--- a/tests/unit/controllers/admin/TalkControllerTest.php
+++ b/tests/unit/controllers/admin/TalkControllerTest.php
@@ -38,6 +38,7 @@ class AdminTalkControllerTest extends PHPUnit_Framework_TestCase
         // Create a fake request
         $req = m::mock('Symfony\Component\HttpFoundation\Request');
         $req->shouldReceive('get')->with('page')->andReturn(1);
+		$req->shouldReceive('get')->with('sort')->andReturn('title');
         $req->shouldReceive('getRequestUri')->andReturn('foo');
 
         $this->createTestData($app['spot']);


### PR DESCRIPTION
We have a lot of talks in our CFP (399 so far), and we need to be able to go through them in a more non-random order.

I'd like to set up filters, too, but that's a bit more ambitious.